### PR TITLE
Add more comprehensive MCP functionality and fix some open problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An MCP (Model Context Protocol) server for assisting with BioCypher workflows. T
 
 - **Hierarchical Tool Structure**: Navigate through BioCypher workflows with structured guidance
 - **BioCypher Adapter Creation Workflow**: Complete 5-phase framework for creating adapters from any data source
-- **Project Creation Tool**: Generate complete BioCypher projects from templates with Docker support
+- **Project Creation Guidance**: Verify existing directories and get scripted cookiecutter instructions
 - **Adaptive Implementation Process**: Step-by-step guidance for analyzing data sources and implementing appropriate adapter strategies
 - **Implementation Patterns**: Reusable patterns for field mapping, conditional extraction, and progressive fallback
 - **Decision Guidance**: AI-powered recommendations based on data characteristics
@@ -18,11 +18,61 @@ An MCP (Model Context Protocol) server for assisting with BioCypher workflows. T
 ```bash
 # Install dependencies
 uv sync
+```
 
-# Run the MCP server locally
-uv run biocypher-mcp
+#### Using with MCP (Model Context Protocol)
 
-# Or run the web server locally
+Add the following configuration to your MCP settings (typically `mcp.json`):
+
+**Option 1: Connect to Remote Service** (for use only, not development)
+
+```json
+{
+  "mcpServers": {
+    "biocypher-mcp": {
+      "url": "https://mcp.biocypher.org/",
+      "transport": "http"
+    }
+  }
+}
+```
+
+**Option 2: Local Development** (using uv)
+
+```json
+{
+  "mcpServers": {
+    "biocypher-mcp": {
+      "command": "uv",
+      "args": ["run", "python", "-u", "-m", "biocypher_mcp.main"],
+      "workingDirectory": "/path/to/biocypher-mcp",
+      "env": { "PYTHONUNBUFFERED": "1" }
+    }
+  }
+}
+```
+
+Replace `/path/to/biocypher-mcp` with the actual path to your cloned repository.
+
+**Option 3: Local Development** (using virtual environment)
+
+```json
+{
+  "mcpServers": {
+    "biocypher-mcp": {
+      "command": "/path/to/biocypher-mcp/.venv/bin/python",
+      "args": ["-u", "-m", "biocypher_mcp.main"],
+      "workingDirectory": "/path/to/biocypher-mcp",
+      "env": { "PYTHONUNBUFFERED": "1" }
+    }
+  }
+}
+```
+
+#### Running the Web Server
+
+```bash
+# Run the web server locally
 uv run python -m biocypher_mcp.web_server
 ```
 
@@ -48,8 +98,9 @@ The MCP server provides the following tools:
 - **`get_implementation_patterns`** - Get reusable implementation patterns
 - **`get_decision_guidance`** - Get AI-powered recommendations based on data characteristics
 
-### Project Creation Tool
-- **`create_biocypher_project`** - Create a complete BioCypher project from template. Can create in existing directories, preserving data files in 'data/' subdirectory.
+### Project Creation Tools
+- **`check_project_exists`** - Show the expected cookiecutter layout and instructions for handling missing projects
+- **`get_cookiecutter_instructions`** - Provide scripted, non-interactive cookiecutter commands and defaults
 
 ### Configuration Tools
 - **`get_schema_configuration_guidance`** - Get guidance on BioCypher schema configuration
@@ -66,45 +117,34 @@ The web server provides the following endpoints:
 - `GET /patterns` - Implementation patterns
 - `GET /patterns/{pattern_type}` - Specific patterns
 - `POST /decision-guidance` - Decision guidance
-- `POST /project/create` - Create a new BioCypher project
+- `POST /project/check` - Validate whether a BioCypher project already exists at a path
+- `GET /project/cookiecutter-instructions` - Retrieve scripted cookiecutter guidance
 - `GET /health` - Health check
 - `GET /docs` - Interactive API documentation
 
 ## Usage Examples
 
-### Creating a BioCypher Project
+### Preparing a BioCypher Project
 
 ```python
-# Create a new project
-create_biocypher_project(
-    project_name="my-protein-project",
-    project_description="Project for protein-protein interaction data",
-    template_method="cookiecutter",
-    target_directory=".",
-    include_docker=True,
-    include_tests=True,
-    adapter_name="protein_interaction_adapter",
-    data_source_type="api",
-    schema_config=True
-)
+from biocypher_mcp.main import check_project_exists, get_cookiecutter_instructions
 
-# Create in existing directory with data files
-create_biocypher_project(
-    project_name="my-data-project",
-    existing_directory_handling="move",  # or "copy" to keep originals
-    template_method="cookiecutter",
-    data_source_type="file"
-)
+# Inspect the expected cookiecutter layout for your target directory
+structure = check_project_exists("/path/to/project")
+print(structure["expected_structure"])
+print(structure["instruction_if_not_exists"])
+
+# Retrieve scripted cookiecutter instructions and defaults
+instructions = get_cookiecutter_instructions()
+print(instructions["usage"]["non_interactive_mode"]["command_template"])
 ```
 
-Existing files are preserved in `data/` subdirectory when using `existing_directory_handling="move"` or `"copy"`.
+### Next Steps After Running Cookiecutter
 
-### Next Steps After Project Creation
-
-1. Navigate to your project: `cd my-protein-project`
-2. Install dependencies: `uv sync` (or `poetry install`)
-3. Implement your adapter: Edit `src/my_protein_project/adapters/protein_interaction_adapter.py`
-4. Run the project: `python create_knowledge_graph.py`
+1. Run the printed command (fill in project-specific values) to generate the project
+2. Navigate to the new directory and install dependencies (`uv sync` or `poetry install`)
+3. Implement your adapter under `src/<package_name>/adapters/`
+4. Execute your pipeline, e.g. `python create_knowledge_graph.py`
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ An MCP (Model Context Protocol) server for assisting with BioCypher workflows. T
 
 - **Hierarchical Tool Structure**: Navigate through BioCypher workflows with structured guidance
 - **BioCypher Adapter Creation Workflow**: Complete 5-phase framework for creating adapters from any data source
+- **Project Creation Tool**: Generate complete BioCypher projects from templates with Docker support
 - **Adaptive Implementation Process**: Step-by-step guidance for analyzing data sources and implementing appropriate adapter strategies
 - **Implementation Patterns**: Reusable patterns for field mapping, conditional extraction, and progressive fallback
 - **Decision Guidance**: AI-powered recommendations based on data characteristics
@@ -36,6 +37,24 @@ docker-compose ps
 docker-compose logs biocypher-mcp
 ```
 
+## Available Tools
+
+The MCP server provides the following tools:
+
+### Core Workflow Tools
+- **`get_available_workflows`** - List all available BioCypher workflows
+- **`get_adapter_creation_workflow`** - Get detailed adapter creation workflow
+- **`get_phase_guidance`** - Get step-by-step guidance for specific workflow phases
+- **`get_implementation_patterns`** - Get reusable implementation patterns
+- **`get_decision_guidance`** - Get AI-powered recommendations based on data characteristics
+
+### Project Creation Tool
+- **`create_biocypher_project`** - Create a complete BioCypher project from template. Can create in existing directories, preserving data files in 'data/' subdirectory.
+
+### Configuration Tools
+- **`get_schema_configuration_guidance`** - Get guidance on BioCypher schema configuration
+- **`get_resource_management_guidance`** - Get guidance on resource management and caching
+
 ## API Endpoints
 
 The web server provides the following endpoints:
@@ -47,8 +66,45 @@ The web server provides the following endpoints:
 - `GET /patterns` - Implementation patterns
 - `GET /patterns/{pattern_type}` - Specific patterns
 - `POST /decision-guidance` - Decision guidance
+- `POST /project/create` - Create a new BioCypher project
 - `GET /health` - Health check
 - `GET /docs` - Interactive API documentation
+
+## Usage Examples
+
+### Creating a BioCypher Project
+
+```python
+# Create a new project
+create_biocypher_project(
+    project_name="my-protein-project",
+    project_description="Project for protein-protein interaction data",
+    template_method="cookiecutter",
+    target_directory=".",
+    include_docker=True,
+    include_tests=True,
+    adapter_name="protein_interaction_adapter",
+    data_source_type="api",
+    schema_config=True
+)
+
+# Create in existing directory with data files
+create_biocypher_project(
+    project_name="my-data-project",
+    existing_directory_handling="move",  # or "copy" to keep originals
+    template_method="cookiecutter",
+    data_source_type="file"
+)
+```
+
+Existing files are preserved in `data/` subdirectory when using `existing_directory_handling="move"` or `"copy"`.
+
+### Next Steps After Project Creation
+
+1. Navigate to your project: `cd my-protein-project`
+2. Install dependencies: `uv sync` (or `poetry install`)
+3. Implement your adapter: Edit `src/my_protein_project/adapters/protein_interaction_adapter.py`
+4. Run the project: `python create_knowledge_graph.py`
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "fastapi>=0.104.0",
     "uvicorn[standard]>=0.24.0",
     "pydantic>=2.0.0",
+    "cookiecutter>=2.1.0",
+    "gitpython>=3.1.0",
 ]
 
 [dependency-groups]

--- a/src/biocypher_mcp/main.py
+++ b/src/biocypher_mcp/main.py
@@ -3,10 +3,11 @@
 # This module provides a hierarchical MCP tool for BioCypher workflows
 ################################################################################
 from typing import Any, Dict, List, Optional
+from pathlib import Path
 from fastmcp import FastMCP
 
 
-def get_available_workflows() -> Dict[str, Any]:
+def get_available_workflows() -> dict[str, Any]:
     """
     Main entry point tool that provides information about available BioCypher workflows.
     
@@ -16,28 +17,33 @@ def get_available_workflows() -> Dict[str, Any]:
     return {
         "workflows": [
             {
+                "id": "project_creation",
+                "name": "BioCypher Project Creation",
+                "description": "Check if a BioCypher project exists and get instructions for creating one using cookiecutter.",
+                "tools": ["check_project_exists", "get_cookiecutter_instructions"]
+            },
+            {
                 "id": "adapter_creation",
                 "name": "BioCypher Adapter Creation",
-                "description": "Create BioCypher adapters for any data source using adaptive analysis and implementation strategies",
-                "status": "available",
-                "complexity": "adaptive",
-                "estimated_time": "30-120 minutes",
-                "prerequisites": [
-                    "Data source to be integrated",
-                    "Basic understanding of BioCypher concepts",
-                    "Python development environment"
+                "description": "5-phase workflow for creating BioCypher adapters from any data source",
+                "tool": "get_adapter_creation_workflow",
+                "supporting_tools": [
+                    "get_phase_guidance",
+                    "get_implementation_patterns",
+                    "get_decision_guidance"
                 ]
             }
         ],
-        "framework_overview": {
-            "name": "BioCypher Adapter Creation Framework",
-            "description": "A generalized framework for creating BioCypher adapters from any data source, with adaptive analysis and implementation strategies",
-            "core_principles": [
-                "Data-First Approach",
-                "Schema-Driven Development", 
-                "Iterative Refinement"
-            ]
-        }
+        "supporting_tools": [
+            {
+                "tool": "get_schema_configuration_guidance",
+                "description": "Guidance on BioCypher schema configuration"
+            },
+            {
+                "tool": "get_resource_management_guidance",
+                "description": "Guidance on resource management and caching"
+            }
+        ]
     }
 
 
@@ -617,9 +623,9 @@ def get_resource_management_guidance() -> Dict[str, Any]:
     return {
         "resource_management_overview": {
             "name": "BioCypher Resource Management",
-            "description": "Resource management handles downloading, caching, and managing data sources for BioCypher pipelines",
+            "description": "Resource management handles downloading, caching, and managing data sources for BioCypher projects",
             "documentation_reference": "https://biocypher.org/BioCypher/reference/source/download-cache/",
-            "pipeline_position": "Beginning of pipeline - data source acquisition"
+            "pipeline_position": "Beginning of project - data source acquisition"
         },
         "core_components": {
             "resource_base_class": {
@@ -710,11 +716,136 @@ paths = downloader.download(protein_data)
     }
 
 
+def check_project_exists(project_path: str = ".") -> Dict[str, Any]:
+    """
+    Returns the expected BioCypher project structure and instructions for project creation.
+    
+    This function provides the expected structure that should be created by the cookiecutter template.
+    You should check the files and directories yourself to determine if a project already exists.
+    
+    IMPORTANT: If you determine that the project does NOT exist, you MUST use cookiecutter to create it.
+    Do NOT manually create the project structure. Always use the cookiecutter template.
+    
+    Args:
+        project_path: Path to check for an existing project (default: current directory)
+        
+    Returns:
+        Dict containing:
+        - project_path: The path that was checked
+        - expected_structure: The expected directory structure from cookiecutter template
+        - instruction_if_not_exists: Clear instruction on what to do if the project doesn't exist
+        - cookiecutter_template_url: URL of the cookiecutter template
+    """
+    from pathlib import Path
+    
+    path = Path(project_path).resolve()
+    
+    # Expected structure from cookiecutter template
+    expected_structure = {
+        "root": "my-biocypher-pipeline/",
+        "directories": [
+            "config/",
+            "src/my_biocypher_pipeline/",
+            "src/my_biocypher_pipeline/adapters/",
+            "tests/"
+        ],
+        "files": [
+            "config/biocypher_config.yaml",
+            "config/schema_config.yaml",
+            "src/my_biocypher_pipeline/__init__.py",
+            "src/my_biocypher_pipeline/adapters/__init__.py",
+            "src/my_biocypher_pipeline/adapters/my_resource_adapter.py",
+            "tests/__init__.py",
+            "tests/test_my_resource_adapter.py",
+            "create_knowledge_graph.py",
+            "docker-compose.yml",
+            "Dockerfile",
+            "pyproject.toml",
+            "README.md",
+            ".gitignore"
+        ]
+    }
+    
+    instruction_if_not_exists = (
+        "If the project does NOT exist at this location, you MUST use cookiecutter to create it. "
+        "Do NOT manually create files or directories. "
+        "Call get_cookiecutter_instructions() to get the exact commands needed, "
+        "then run cookiecutter with the template URL: https://github.com/biocypher/biocypher-cookiecutter-template.git"
+    )
+    
+    return {
+        "project_path": str(path),
+        "expected_structure": expected_structure,
+        "instruction_if_not_exists": instruction_if_not_exists,
+        "cookiecutter_template_url": "https://github.com/biocypher/biocypher-cookiecutter-template"
+    }
+
+
+def get_cookiecutter_instructions() -> Dict[str, Any]:
+    """
+    Provides instructions on how to create a BioCypher project using cookiecutter.
+    
+    This function informs users how to install cookiecutter (if not present) and
+    how to run it to create a new BioCypher project. It does not make assumptions
+    about directory structure or project name - the LLM should check with the user
+    for these details.
+    
+    Returns:
+        Dict containing installation and usage instructions for cookiecutter
+    """
+    return {
+        "template_url": "https://github.com/biocypher/biocypher-cookiecutter-template",
+        "installation": {
+            "description": "Install cookiecutter if not already installed",
+            "methods": [
+                {
+                    "method": "pip",
+                    "command": "pip install cookiecutter"
+                },
+                {
+                    "method": "conda",
+                    "command": "conda install -c conda-forge cookiecutter"
+                },
+                {
+                    "method": "uv",
+                    "command": "uv pip install cookiecutter"
+                }
+            ]
+        },
+        "usage": {
+            "description": "Run cookiecutter to create a new BioCypher project",
+            "command": "cookiecutter https://github.com/biocypher/biocypher-cookiecutter-template.git",
+            "interactive_mode": "Cookiecutter will prompt you for project details interactively",
+            "non_interactive_mode": {
+                "description": "To run non-interactively, use the --no-input flag and provide context",
+                "command": "cookiecutter https://github.com/biocypher/biocypher-cookiecutter-template.git --no-input",
+                "note": "You'll need to provide all required parameters via --extra-context or a config file"
+            }
+        },
+        "expected_output": {
+            "description": "After running cookiecutter, you should have a project directory with the structure shown by check_project_exists()",
+            "next_steps": [
+                "Navigate to the created project directory",
+                "Install dependencies (e.g., 'uv sync' or 'poetry install')",
+                "Review and customize the generated files",
+                "Implement your adapter in src/<project_name>/adapters/"
+            ]
+        },
+        "important_notes": [
+            "Ask the user for the desired project name and location before running cookiecutter",
+            "The cookiecutter template will prompt for various configuration options",
+            "More information can be found in the cookiecutter README at the template URL"
+        ]
+    }
+
+
 # Create the FastMCP instance
 mcp = FastMCP("biocypher_mcp")
 
 # Register all tools
 mcp.tool(get_available_workflows)
+mcp.tool(check_project_exists)
+mcp.tool(get_cookiecutter_instructions)
 mcp.tool(get_adapter_creation_workflow)
 mcp.tool(get_phase_guidance)
 mcp.tool(get_implementation_patterns)

--- a/src/biocypher_mcp/main.py
+++ b/src/biocypher_mcp/main.py
@@ -728,9 +728,41 @@ mcp.tool(get_resource_management_guidance)
 app = mcp.http_app(path="/")
 
 def main():
-    """Run the MCP server over Streamable HTTP using uvicorn."""
-    import uvicorn
-    uvicorn.run("biocypher_mcp.main:app", host="0.0.0.0", port=8000)
+    """Run the MCP server.
+    
+    By default, runs in stdio mode for development.
+    For production HTTP mode, use: python -m biocypher_mcp.main --transport http
+    """
+    import sys
+    import argparse
+    
+    parser = argparse.ArgumentParser(description="Run the BioCypher MCP server")
+    parser.add_argument(
+        "--transport", 
+        choices=["stdio", "http"], 
+        default="stdio",
+        help="Transport method (default: stdio)"
+    )
+    parser.add_argument(
+        "--port", 
+        type=int, 
+        default=8000,
+        help="Port for HTTP transport (default: 8000)"
+    )
+    parser.add_argument(
+        "--host", 
+        default="0.0.0.0",
+        help="Host for HTTP transport (default: 0.0.0.0)"
+    )
+    
+    args = parser.parse_args()
+    
+    if args.transport == "http":
+        print(f"Starting BioCypher MCP server in HTTP mode on {args.host}:{args.port}")
+        mcp.run(transport="http", port=args.port, host=args.host)
+    else:
+        print("Starting BioCypher MCP server in stdio mode")
+        mcp.run(transport="stdio")
 
 
 if __name__ == "__main__":

--- a/src/biocypher_mcp/main.py
+++ b/src/biocypher_mcp/main.py
@@ -51,6 +51,8 @@ def get_adapter_creation_workflow() -> Dict[str, Any]:
     """
     Provides detailed information about the adapter creation workflow.
     
+    For implementation details, code examples, and patterns, refer to the dedicated BioCypher LLM documentation.
+    
     Returns:
         Dict containing the workflow structure and phases
     """
@@ -58,6 +60,16 @@ def get_adapter_creation_workflow() -> Dict[str, Any]:
         "workflow_id": "adapter_creation",
         "name": "BioCypher Adapter Creation Workflow",
         "description": "Complete workflow for creating BioCypher adapters from any data source",
+        "llm_documentation": {
+            "primary_reference": "https://biocypher.org/BioCypher/llms.txt",
+            "adapter_guide": "https://biocypher.org/BioCypher/llms-adapters.txt - Complete guide for creating BioCypher adapters",
+            "example_adapter": "https://biocypher.org/BioCypher/llms-example-adapter.txt - Full working example of a GEO adapter",
+            "key_sections": [
+                "Adapters section - Interface, node/edge formats",
+                "Common Patterns > Adapter Patterns",
+                "Data Processing - Node/edge creation formats"
+            ]
+        },
         "phases": [
             {
                 "phase": 1,
@@ -141,6 +153,10 @@ def get_phase_guidance(phase_number: int) -> Dict[str, Any]:
     """
     Provides detailed guidance for a specific phase of the adapter creation workflow.
     
+    For implementation code examples and patterns, refer to the BioCypher LLM documentation:
+    - https://biocypher.org/BioCypher/llms-adapters.txt (adapter guide)
+    - https://biocypher.org/BioCypher/llms-example-adapter.txt (working example)
+    
     Args:
         phase_number: The phase number (1-5) to get guidance for
         
@@ -198,7 +214,8 @@ def assess_schema_requirements(data_analysis, existing_schema=None):
                 "Data source type identification",
                 "Structure analysis report", 
                 "Schema requirements assessment"
-            ]
+            ],
+            "llm_documentation_reference": "For adapter interface details and data formats, see https://biocypher.org/BioCypher/llms-adapters.txt"
         },
         2: {
             "phase_name": "Implementation Strategy Design",
@@ -255,7 +272,8 @@ def design_extraction_strategy(data_analysis):
             "outputs_expected": [
                 "Architecture choice (Simple/Series/Hierarchical/Custom)",
                 "Extraction strategy document"
-            ]
+            ],
+            "llm_documentation_reference": "For adapter patterns and implementation strategies, see https://biocypher.org/BioCypher/llms.txt > Common Patterns > Adapter Patterns"
         },
         3: {
             "phase_name": "Implementation",
@@ -311,7 +329,8 @@ def map_fields_to_schema(self, data_item, field_mapping):
             "outputs_expected": [
                 "Working adapter code",
                 "Field mapping configuration"
-            ]
+            ],
+            "llm_documentation_reference": "For implementation details, node/edge formats, and working examples, see https://biocypher.org/BioCypher/llms-example-adapter.txt and https://biocypher.org/BioCypher/llms-adapters.txt"
         },
         4: {
             "phase_name": "Quality Assurance",
@@ -410,6 +429,11 @@ def generate_adaptive_documentation(adapter, data_analysis):
 def get_implementation_patterns(pattern_type: Optional[str] = None) -> Dict[str, Any]:
     """
     Provides implementation patterns for different data scenarios.
+    
+    For comprehensive adapter patterns and working examples, refer to:
+    - https://biocypher.org/BioCypher/llms.txt > Common Patterns > Adapter Patterns
+    - https://biocypher.org/BioCypher/llms-adapters.txt (complete adapter guide)
+    - https://biocypher.org/BioCypher/llms-example-adapter.txt (working GEO adapter example)
     
     Args:
         pattern_type: Optional specific pattern type to retrieve
@@ -552,167 +576,83 @@ def get_decision_guidance(data_characteristics: Dict[str, Any]) -> Dict[str, Any
 
 def get_schema_configuration_guidance() -> Dict[str, Any]:
     """
-    Provides comprehensive guidance on BioCypher schema configuration.
+    Provides guidance on BioCypher schema configuration.
+    
+    For comprehensive details, refer to the dedicated BioCypher LLM documentation.
     
     Returns:
-        Dict containing schema configuration guidance and best practices
+        Dict containing schema configuration overview and references to detailed documentation
     """
     return {
-        "schema_configuration_overview": {
+        "overview": {
             "name": "BioCypher Schema Configuration",
-            "description": "Schema configuration defines how data sources map to BioCypher's ontological structure",
+            "description": "Schema configuration defines how data sources map to BioCypher's ontological structure using YAML",
             "file_location": "config/schema_config.yaml",
-            "documentation_reference": "https://biocypher.org/BioCypher/learn/tutorials/tutorial002_handling_ontologies/"
+            "key_concept": "Uses input_label to map adapter outputs to schema concepts"
         },
-        "schema_file_structure": {
-            "standard_location": "config/schema_config.yaml",
-            "alternative_locations": [
-                "schema_config.yaml",
-                "config/schema.yaml",
-                "biocypher_schema.yaml"
-            ],
+        "llm_documentation": {
+            "primary_reference": "https://biocypher.org/BioCypher/llms.txt",
+            "schema_section": "Schema Configuration section in llms.txt",
+            "details": [
+                "YAML-based schema definition",
+                "Defines node types, edge types, and their properties",
+                "Uses input_label to map adapter outputs to schema concepts",
+                "Supports inheritance and property overrides"
+            ]
+        },
+        "quick_reference": {
             "file_format": "YAML",
-            "naming_convention": "schema_config.yaml"
+            "standard_location": "config/schema_config.yaml",
+            "core_fields": [
+                "represented_as: node or edge",
+                "preferred_id: identifier source",
+                "input_label: data source field name (must match adapter output)"
+            ],
+            "additional_resources": [
+                "https://biocypher.org/BioCypher/learn/tutorials/tutorial002_handling_ontologies/",
+                "https://biocypher.org/BioCypher/llms-adapters.txt (for adapter examples)"
+            ]
         },
-        "core_concepts": {
-            "ontology_grounding": {
-                "description": "BioCypher uses ontologies to ground knowledge graph contents in biology",
-                "benefits": [
-                    "Machine readability and automation capabilities",
-                    "Accessibility for biologically oriented researchers",
-                    "Standardized terminology and relationships"
-                ],
-                "default_ontology": "Biolink model"
-            },
-            "schema_configuration": {
-                "description": "YAML file that maps data concepts to ontological classes",
-                "purpose": "Define how data sources map to BioCypher's ontological structure",
-                "key_components": [
-                    "Class definitions",
-                    "Property mappings", 
-                    "Relationship definitions",
-                    "Ontology inheritance"
-                ]
-            }
-        },
-        "schema_configuration_guidelines": {
-            "basic_structure": {
-                "description": "Each class in schema_config.yaml defines how data maps to ontological concepts",
-                "required_fields": [
-                    "represented_as: node or edge",
-                    "preferred_id: identifier source",
-                    "input_label: data source field name"
-                ],
-                "optional_fields": [
-                    "synonym_for: ontology class synonym",
-                    "is_a: parent ontology class",
-                    "properties: additional attributes"
-                ]
-            }
-        }
+        "note": "For detailed schema configuration examples and patterns, refer to the BioCypher LLM documentation at https://biocypher.org/BioCypher/llms.txt"
     }
 
 
 def get_resource_management_guidance() -> Dict[str, Any]:
     """
-    Provides comprehensive guidance on BioCypher resource management and download/cache functionality.
+    Provides guidance on BioCypher resource management and download/cache functionality.
+    
+    For comprehensive details, refer to the dedicated BioCypher LLM documentation.
     
     Returns:
-        Dict containing resource management guidance and best practices
+        Dict containing resource management overview and references to detailed documentation
     """
     return {
-        "resource_management_overview": {
+        "overview": {
             "name": "BioCypher Resource Management",
             "description": "Resource management handles downloading, caching, and managing data sources for BioCypher projects",
-            "documentation_reference": "https://biocypher.org/BioCypher/reference/source/download-cache/",
             "pipeline_position": "Beginning of project - data source acquisition"
         },
-        "core_components": {
-            "resource_base_class": {
-                "name": "Resource Base Class",
-                "description": "Abstract base class for managing downloadable resources",
-                "location": "biocypher/biocypher/_get.py",
-                "key_features": [
-                    "File downloads",
-                    "API requests", 
-                    "Local caching",
-                    "Lifetime management"
-                ]
-            },
-            "downloader": {
-                "name": "Downloader",
-                "description": "Manages resource downloads and caching",
-                "key_features": [
-                    "Automatic caching",
-                    "Lifetime management",
-                    "Cache validation",
-                    "Multiple resource handling"
-                ]
-            },
+        "llm_documentation": {
+            "primary_reference": "https://biocypher.org/BioCypher/llms.txt",
+            "utility_functions_section": "Utility Functions > Download and Cache section in llms.txt",
+            "available_functions": [
+                "download_and_cache_file(): Download files with caching",
+                "download_and_cache_ftp(): FTP file downloads",
+                "download_and_cache_http(): HTTP file downloads"
+            ]
+        },
+        "quick_reference": {
             "resource_types": {
-                "file_download": {
-                    "name": "FileDownload",
-                    "description": "Downloads files from URLs",
-                    "use_case": "Static data files, databases, ontologies"
-                },
-                "api_request": {
-                    "name": "APIRequest", 
-                    "description": "Makes API requests and caches responses",
-                    "use_case": "REST APIs, web services, dynamic data"
-                }
-            }
-        },
-        "resource_initialization": {
-            "basic_structure": {
-                "description": "Initialize a Resource with name, URL(s), and lifetime",
-                "required_parameters": [
-                    "name: Resource identifier",
-                    "url_s: URL or list of URLs",
-                    "lifetime: Cache lifetime in days (0 = permanent)"
-                ],
-                "example": """
-from biocypher import FileDownload
-
-# Single file resource
-protein_data = FileDownload(
-    name="uniprot_proteins",
-    url_s="https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_sprot.dat.gz",
-    lifetime=7  # Refresh weekly
-)
-
-# Multiple file resource
-pathway_data = FileDownload(
-    name="reactome_pathways", 
-    url_s=[
-        "https://reactome.org/download/current/ReactomePathways.txt",
-        "https://reactome.org/download/current/ReactomePathwaysRelation.txt"
-    ],
-    lifetime=30  # Refresh monthly
-)
-"""
-            }
-        },
-        "downloader_usage": {
-            "initialization": {
-                "description": "Initialize Downloader with optional cache directory",
-                "example": """
-from biocypher import Downloader
-
-# Use default temporary directory
-downloader = Downloader()
-
-# Use custom cache directory
-downloader = Downloader(cache_dir="/path/to/cache")
-"""
+                "FileDownload": "Downloads files from URLs (static data files, databases, ontologies)",
+                "APIRequest": "Makes API requests and caches responses (REST APIs, web services)"
             },
-            "downloading_resources": {
-                "description": "Download resources with automatic caching",
-                "example": """
-# Download single resource
-paths = downloader.download(protein_data)
-"""
-            }
-        }
+            "basic_usage": "Initialize Resource with name, URL(s), and lifetime. Use Downloader for managing downloads and caching.",
+            "additional_resources": [
+                "https://biocypher.org/BioCypher/reference/source/download-cache/",
+                "https://biocypher.org/BioCypher/llms-adapters.txt (for adapter examples using resources)"
+            ]
+        },
+        "note": "For detailed resource management examples, code patterns, and API reference, refer to the BioCypher LLM documentation at https://biocypher.org/BioCypher/llms.txt"
     }
 
 
@@ -813,13 +753,77 @@ def get_cookiecutter_instructions() -> Dict[str, Any]:
             ]
         },
         "usage": {
-            "description": "Run cookiecutter to create a new BioCypher project",
-            "command": "cookiecutter https://github.com/biocypher/biocypher-cookiecutter-template.git",
-            "interactive_mode": "Cookiecutter will prompt you for project details interactively",
+            "description": "Run cookiecutter to create a new BioCypher project (always non-interactive; pre-fill everything you can)",
             "non_interactive_mode": {
-                "description": "To run non-interactively, use the --no-input flag and provide context",
-                "command": "cookiecutter https://github.com/biocypher/biocypher-cookiecutter-template.git --no-input",
-                "note": "You'll need to provide all required parameters via --extra-context or a config file"
+                "description": (
+                    "Determine sensible defaults for every cookiecutter prompt first. "
+                    "Only ask the user for values that cannot be inferred or that they explicitly want to control. "
+                    "After confirming any custom values, run cookiecutter with --no-input and pass key=value pairs "
+                    "for every prompt so no terminal interaction is required."
+                ),
+                "default_context_strategy": [
+                    {
+                        "field": "project_name",
+                        "default": "Ask the user for their desired project/directory name (required)."
+                    },
+                    {
+                        "field": "package_name",
+                        "default": "project_name converted to snake_case."
+                    },
+                    {
+                        "field": "adapter_name",
+                        "default": "package_name + '_adapter'."
+                    },
+                    {
+                        "field": "project_description",
+                        "default": "Brief sentence like 'BioCypher project for <data source>' if known."
+                    },
+                    {
+                        "field": "data_source_type",
+                        "default": "\"file\" unless the user indicates api/database/custom."
+                    },
+                    {
+                        "field": "include_docker / include_tests / schema_config",
+                        "default": "\"y\" unless the user requests otherwise."
+                    },
+                    {
+                        "field": "author_name / author_email / version",
+                        "default": "\"BioCypher User\", \"user@example.com\", \"0.1.0\" (override if the user provides real info)."
+                    }
+                ],
+                "required_context": [
+                    "project_name",
+                    "project_description",
+                    "package_name",
+                    "adapter_name",
+                    "data_source_type",
+                    "include_docker (\"y\" or \"n\")",
+                    "include_tests (\"y\" or \"n\")",
+                    "schema_config (\"y\" or \"n\")",
+                    "author_name",
+                    "author_email",
+                    "version"
+                ],
+                "command_template": (
+                    "cookiecutter https://github.com/biocypher/biocypher-cookiecutter-template.git "
+                    "--no-input "
+                    "project_name=\"{project_name}\" "
+                    "project_description=\"{project_description}\" "
+                    "package_name=\"{package_name}\" "
+                    "adapter_name=\"{adapter_name}\" "
+                    "data_source_type=\"{data_source_type}\" "
+                    "include_docker=\"{include_docker}\" "
+                    "include_tests=\"{include_tests}\" "
+                    "schema_config=\"{schema_config}\" "
+                    "author_name=\"{author_name}\" "
+                    "author_email=\"{author_email}\" "
+                    "version=\"{version}\""
+                ),
+                "notes": [
+                    "Pre-fill defaults and only ask the user for fields that cannot be inferred or that they want to customize.",
+                    "Confirm the final context before running the command.",
+                    "Never run interactive cookiecutter prompts; always provide the complete context yourself."
+                ]
             }
         },
         "expected_output": {

--- a/src/biocypher_mcp/main.py
+++ b/src/biocypher_mcp/main.py
@@ -544,6 +544,172 @@ def get_decision_guidance(data_characteristics: Dict[str, Any]) -> Dict[str, Any
     }
 
 
+def get_schema_configuration_guidance() -> Dict[str, Any]:
+    """
+    Provides comprehensive guidance on BioCypher schema configuration.
+    
+    Returns:
+        Dict containing schema configuration guidance and best practices
+    """
+    return {
+        "schema_configuration_overview": {
+            "name": "BioCypher Schema Configuration",
+            "description": "Schema configuration defines how data sources map to BioCypher's ontological structure",
+            "file_location": "config/schema_config.yaml",
+            "documentation_reference": "https://biocypher.org/BioCypher/learn/tutorials/tutorial002_handling_ontologies/"
+        },
+        "schema_file_structure": {
+            "standard_location": "config/schema_config.yaml",
+            "alternative_locations": [
+                "schema_config.yaml",
+                "config/schema.yaml",
+                "biocypher_schema.yaml"
+            ],
+            "file_format": "YAML",
+            "naming_convention": "schema_config.yaml"
+        },
+        "core_concepts": {
+            "ontology_grounding": {
+                "description": "BioCypher uses ontologies to ground knowledge graph contents in biology",
+                "benefits": [
+                    "Machine readability and automation capabilities",
+                    "Accessibility for biologically oriented researchers",
+                    "Standardized terminology and relationships"
+                ],
+                "default_ontology": "Biolink model"
+            },
+            "schema_configuration": {
+                "description": "YAML file that maps data concepts to ontological classes",
+                "purpose": "Define how data sources map to BioCypher's ontological structure",
+                "key_components": [
+                    "Class definitions",
+                    "Property mappings", 
+                    "Relationship definitions",
+                    "Ontology inheritance"
+                ]
+            }
+        },
+        "schema_configuration_guidelines": {
+            "basic_structure": {
+                "description": "Each class in schema_config.yaml defines how data maps to ontological concepts",
+                "required_fields": [
+                    "represented_as: node or edge",
+                    "preferred_id: identifier source",
+                    "input_label: data source field name"
+                ],
+                "optional_fields": [
+                    "synonym_for: ontology class synonym",
+                    "is_a: parent ontology class",
+                    "properties: additional attributes"
+                ]
+            }
+        }
+    }
+
+
+def get_resource_management_guidance() -> Dict[str, Any]:
+    """
+    Provides comprehensive guidance on BioCypher resource management and download/cache functionality.
+    
+    Returns:
+        Dict containing resource management guidance and best practices
+    """
+    return {
+        "resource_management_overview": {
+            "name": "BioCypher Resource Management",
+            "description": "Resource management handles downloading, caching, and managing data sources for BioCypher pipelines",
+            "documentation_reference": "https://biocypher.org/BioCypher/reference/source/download-cache/",
+            "pipeline_position": "Beginning of pipeline - data source acquisition"
+        },
+        "core_components": {
+            "resource_base_class": {
+                "name": "Resource Base Class",
+                "description": "Abstract base class for managing downloadable resources",
+                "location": "biocypher/biocypher/_get.py",
+                "key_features": [
+                    "File downloads",
+                    "API requests", 
+                    "Local caching",
+                    "Lifetime management"
+                ]
+            },
+            "downloader": {
+                "name": "Downloader",
+                "description": "Manages resource downloads and caching",
+                "key_features": [
+                    "Automatic caching",
+                    "Lifetime management",
+                    "Cache validation",
+                    "Multiple resource handling"
+                ]
+            },
+            "resource_types": {
+                "file_download": {
+                    "name": "FileDownload",
+                    "description": "Downloads files from URLs",
+                    "use_case": "Static data files, databases, ontologies"
+                },
+                "api_request": {
+                    "name": "APIRequest", 
+                    "description": "Makes API requests and caches responses",
+                    "use_case": "REST APIs, web services, dynamic data"
+                }
+            }
+        },
+        "resource_initialization": {
+            "basic_structure": {
+                "description": "Initialize a Resource with name, URL(s), and lifetime",
+                "required_parameters": [
+                    "name: Resource identifier",
+                    "url_s: URL or list of URLs",
+                    "lifetime: Cache lifetime in days (0 = permanent)"
+                ],
+                "example": """
+from biocypher import FileDownload
+
+# Single file resource
+protein_data = FileDownload(
+    name="uniprot_proteins",
+    url_s="https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/uniprot_sprot.dat.gz",
+    lifetime=7  # Refresh weekly
+)
+
+# Multiple file resource
+pathway_data = FileDownload(
+    name="reactome_pathways", 
+    url_s=[
+        "https://reactome.org/download/current/ReactomePathways.txt",
+        "https://reactome.org/download/current/ReactomePathwaysRelation.txt"
+    ],
+    lifetime=30  # Refresh monthly
+)
+"""
+            }
+        },
+        "downloader_usage": {
+            "initialization": {
+                "description": "Initialize Downloader with optional cache directory",
+                "example": """
+from biocypher import Downloader
+
+# Use default temporary directory
+downloader = Downloader()
+
+# Use custom cache directory
+downloader = Downloader(cache_dir="/path/to/cache")
+"""
+            },
+            "downloading_resources": {
+                "description": "Download resources with automatic caching",
+                "example": """
+# Download single resource
+paths = downloader.download(protein_data)
+"""
+            }
+        }
+    }
+
+
 # Create the FastMCP instance
 mcp = FastMCP("biocypher_mcp")
 
@@ -553,6 +719,8 @@ mcp.tool(get_adapter_creation_workflow)
 mcp.tool(get_phase_guidance)
 mcp.tool(get_implementation_patterns)
 mcp.tool(get_decision_guidance)
+mcp.tool(get_schema_configuration_guidance)
+mcp.tool(get_resource_management_guidance)
 
 
 # --- Streamable HTTP transport (ASGI app) ---

--- a/src/biocypher_mcp/web_server.py
+++ b/src/biocypher_mcp/web_server.py
@@ -16,7 +16,9 @@ from .main import (
     get_adapter_creation_workflow,
     get_phase_guidance,
     get_implementation_patterns,
-    get_decision_guidance
+    get_decision_guidance,
+    check_project_exists,
+    get_cookiecutter_instructions
 )
 
 
@@ -36,6 +38,11 @@ class ErrorResponse(BaseModel):
     """Model for error responses."""
     error: str
     detail: Optional[str] = None
+
+
+class ProjectPathRequest(BaseModel):
+    """Model for project path check requests."""
+    project_path: str = "."
 
 
 # Create FastAPI app
@@ -72,6 +79,8 @@ async def root():
             "patterns": "/patterns",
             "patterns_specific": "/patterns/{pattern_type}",
             "decision_guidance": "/decision-guidance",
+            "check_project": "/project/check",
+            "cookiecutter_instructions": "/project/cookiecutter-instructions",
             "docs": "/docs"
         }
     }
@@ -141,6 +150,24 @@ async def get_decision(data_characteristics: DataCharacteristics):
         return get_decision_guidance(data_dict)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error generating decision guidance: {str(e)}")
+
+
+@app.post("/project/check", response_model=Dict[str, Any])
+async def check_project(request: ProjectPathRequest):
+    """Check if a BioCypher project exists at the given path."""
+    try:
+        return check_project_exists(request.project_path)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error checking project: {str(e)}")
+
+
+@app.get("/project/cookiecutter-instructions", response_model=Dict[str, Any])
+async def get_cookiecutter_info():
+    """Get instructions for creating a BioCypher project using cookiecutter."""
+    try:
+        return get_cookiecutter_instructions()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error retrieving instructions: {str(e)}")
 
 
 @app.get("/health", response_model=Dict[str, str])

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -15,6 +15,8 @@ from biocypher_mcp.main import (
     get_phase_guidance,
     get_implementation_patterns,
     get_decision_guidance,
+    check_project_exists,
+    get_cookiecutter_instructions,
     mcp
 )
 
@@ -28,7 +30,7 @@ class TestAvailableWorkflows:
         
         # Check required fields
         assert "workflows" in result
-        assert "framework_overview" in result
+        assert "supporting_tools" in result
         
         # Check workflows is a list
         assert isinstance(result["workflows"], list)
@@ -39,9 +41,13 @@ class TestAvailableWorkflows:
         result = get_available_workflows()
         workflow = result["workflows"][0]
         
-        expected_fields = ["id", "name", "description", "status", "complexity", "estimated_time", "prerequisites"]
+        # All workflows should have these fields
+        expected_fields = ["id", "name", "description"]
         for field in expected_fields:
             assert field in workflow, f"Missing field: {field}"
+        
+        # Workflows may have either "tool" (singular) or "tools" (plural)
+        assert "tool" in workflow or "tools" in workflow, "Workflow should have either 'tool' or 'tools' field"
 
     def test_adapter_creation_workflow(self):
         """Test that the adapter creation workflow is available."""
@@ -52,21 +58,34 @@ class TestAvailableWorkflows:
         assert adapter_workflow is not None, "Adapter creation workflow should be available"
         
         assert adapter_workflow["name"] == "BioCypher Adapter Creation"
-        assert "adaptive analysis" in adapter_workflow["description"]
-        assert adapter_workflow["status"] == "available"
+        assert "5-phase workflow" in adapter_workflow["description"]
+        assert "supporting_tools" in adapter_workflow
 
-    def test_framework_overview(self):
-        """Test that the framework overview is provided."""
+    def test_project_creation_workflow(self):
+        """Test that the project creation workflow is available."""
         result = get_available_workflows()
-        overview = result["framework_overview"]
+        workflows = result["workflows"]
         
-        assert "name" in overview
-        assert "description" in overview
-        assert "core_principles" in overview
+        project_workflow = next((w for w in workflows if w["id"] == "project_creation"), None)
+        assert project_workflow is not None, "Project creation workflow should be available"
         
-        assert overview["name"] == "BioCypher Adapter Creation Framework"
-        assert isinstance(overview["core_principles"], list)
-        assert len(overview["core_principles"]) == 3
+        assert project_workflow["name"] == "BioCypher Project Creation"
+        assert "cookiecutter" in project_workflow["description"].lower()
+        assert "tools" in project_workflow
+        assert "check_project_exists" in project_workflow["tools"]
+        assert "get_cookiecutter_instructions" in project_workflow["tools"]
+
+    def test_supporting_tools(self):
+        """Test that supporting tools are provided."""
+        result = get_available_workflows()
+        supporting_tools = result["supporting_tools"]
+        
+        assert isinstance(supporting_tools, list)
+        assert len(supporting_tools) > 0
+        
+        for tool in supporting_tools:
+            assert "tool" in tool
+            assert "description" in tool
 
 
 class TestAdapterCreationWorkflow:
@@ -331,7 +350,9 @@ class TestMCPToolIntegration:
             get_adapter_creation_workflow,
             get_phase_guidance,
             get_implementation_patterns,
-            get_decision_guidance
+            get_decision_guidance,
+            check_project_exists,
+            get_cookiecutter_instructions
         ]
         
         for tool in tools:
@@ -344,6 +365,8 @@ class TestMCPToolIntegration:
         assert isinstance(get_phase_guidance(1), dict)
         assert isinstance(get_implementation_patterns(), dict)
         assert isinstance(get_decision_guidance({}), dict)
+        assert isinstance(check_project_exists(), dict)
+        assert isinstance(get_cookiecutter_instructions(), dict)
 
     def test_hierarchical_navigation(self):
         """Test that the tools support hierarchical navigation."""
@@ -366,3 +389,90 @@ class TestMCPToolIntegration:
         # Get decision guidance
         guidance = get_decision_guidance({"structure_type": "flat"})
         assert len(guidance["recommendations"]) > 0
+
+
+class TestProjectCreation:
+    """Test the project creation tools."""
+
+    def test_check_project_exists_structure(self):
+        """Test that check_project_exists returns the expected structure."""
+        result = check_project_exists()
+        
+        assert "project_path" in result
+        assert "expected_structure" in result
+        assert "instruction_if_not_exists" in result
+        assert "cookiecutter_template_url" in result
+        assert "cookiecutter" in result["instruction_if_not_exists"].lower()
+        assert "MUST" in result["instruction_if_not_exists"] or "must" in result["instruction_if_not_exists"]
+
+    def test_check_project_exists_with_path(self, tmp_path):
+        """Test checking project existence with a specific path."""
+        result = check_project_exists(str(tmp_path))
+        
+        assert result["project_path"] == str(tmp_path.resolve())
+        assert "expected_structure" in result
+        assert "instruction_if_not_exists" in result
+        assert "cookiecutter" in result["instruction_if_not_exists"].lower()
+        assert "MUST" in result["instruction_if_not_exists"] or "must" in result["instruction_if_not_exists"]
+
+    def test_check_project_exists_returns_structure(self, tmp_path):
+        """Test that check_project_exists returns expected structure regardless of project existence."""
+        # Create a minimal BioCypher project structure
+        (tmp_path / "create_knowledge_graph.py").write_text("# Test")
+        (tmp_path / "config").mkdir()
+        (tmp_path / "config" / "biocypher_config.yaml").write_text("test: config")
+        (tmp_path / "config" / "schema_config.yaml").write_text("test: schema")
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'test'")
+        (tmp_path / "src").mkdir()
+        
+        result = check_project_exists(str(tmp_path))
+        
+        # Function should return structure and instructions regardless of whether project exists
+        assert "expected_structure" in result
+        assert "instruction_if_not_exists" in result
+        assert "cookiecutter_template_url" in result
+
+    def test_check_project_exists_expected_structure(self):
+        """Test that expected_structure contains the correct information."""
+        result = check_project_exists()
+        expected = result["expected_structure"]
+        
+        assert "root" in expected
+        assert "directories" in expected
+        assert "files" in expected
+        assert isinstance(expected["directories"], list)
+        assert isinstance(expected["files"], list)
+        assert "config/" in expected["directories"]
+        assert "create_knowledge_graph.py" in expected["files"]
+        assert "config/biocypher_config.yaml" in expected["files"]
+
+    def test_get_cookiecutter_instructions_structure(self):
+        """Test that get_cookiecutter_instructions returns the expected structure."""
+        result = get_cookiecutter_instructions()
+        
+        assert "template_url" in result
+        assert "installation" in result
+        assert "usage" in result
+        assert "expected_output" in result
+        assert "important_notes" in result
+
+    def test_get_cookiecutter_instructions_content(self):
+        """Test that cookiecutter instructions contain the expected content."""
+        result = get_cookiecutter_instructions()
+        
+        assert "biocypher-cookiecutter-template" in result["template_url"]
+        assert "methods" in result["installation"]
+        assert len(result["installation"]["methods"]) > 0
+        assert "command" in result["usage"]
+        assert "cookiecutter" in result["usage"]["command"]
+        assert isinstance(result["important_notes"], list)
+        assert len(result["important_notes"]) > 0
+
+    def test_get_cookiecutter_instructions_installation_methods(self):
+        """Test that installation methods are provided."""
+        result = get_cookiecutter_instructions()
+        methods = result["installation"]["methods"]
+        
+        method_names = [m["method"] for m in methods]
+        assert "pip" in method_names
+        assert "cookiecutter" in methods[0]["command"]

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -463,8 +463,9 @@ class TestProjectCreation:
         assert "biocypher-cookiecutter-template" in result["template_url"]
         assert "methods" in result["installation"]
         assert len(result["installation"]["methods"]) > 0
-        assert "command" in result["usage"]
-        assert "cookiecutter" in result["usage"]["command"]
+        assert "non_interactive_mode" in result["usage"]
+        command_template = result["usage"]["non_interactive_mode"]["command_template"]
+        assert "cookiecutter" in command_template
         assert isinstance(result["important_notes"], list)
         assert len(result["important_notes"]) > 0
 

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,19 @@ wheels = [
 ]
 
 [[package]]
+name = "arrow"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "types-python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/00/0f6e8fcdb23ea632c866620cc872729ff43ed91d284c866b515c6342b173/arrow-1.3.0.tar.gz", hash = "sha256:d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85", size = 131960, upload-time = "2023-09-30T22:11:18.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/ed/e97229a566617f2ae958a6b13e7cc0f585470eac730a73e9e82c32a3cdd2/arrow-1.3.0-py3-none-any.whl", hash = "sha256:c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80", size = 66419, upload-time = "2023-09-30T22:11:16.072Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -47,12 +60,26 @@ wheels = [
 ]
 
 [[package]]
+name = "binaryornot"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/fe/7ebfec74d49f97fc55cd38240c7a7d08134002b1e14be8c3897c0dd5e49b/binaryornot-0.4.4.tar.gz", hash = "sha256:359501dfc9d40632edc9fac890e19542db1a287bbcfa58175b66658392018061", size = 371054, upload-time = "2017-08-03T15:55:25.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/7e/f7b6f453e6481d1e233540262ccbfcf89adcd43606f44a028d7f5fae5eb2/binaryornot-0.4.4-py2.py3-none-any.whl", hash = "sha256:b8b71173c917bddcd2c16070412e369c3ed7f0528926f70cac18a6c97fd563e4", size = 9006, upload-time = "2017-08-03T15:55:31.23Z" },
+]
+
+[[package]]
 name = "biocypher-mcp"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "cookiecutter" },
     { name = "fastapi" },
     { name = "fastmcp" },
+    { name = "gitpython" },
     { name = "pydantic" },
     { name = "requests" },
     { name = "uvicorn", extra = ["standard"] },
@@ -66,8 +93,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cookiecutter", specifier = ">=2.1.0" },
     { name = "fastapi", specifier = ">=0.104.0" },
     { name = "fastmcp", specifier = ">=2.7.1" },
+    { name = "gitpython", specifier = ">=3.1.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0" },
@@ -162,6 +191,15 @@ wheels = [
 ]
 
 [[package]]
+name = "chardet"
+version = "5.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618, upload-time = "2023-08-01T19:23:02.662Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385, upload-time = "2023-08-01T19:23:00.661Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -233,6 +271,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cookiecutter"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "arrow" },
+    { name = "binaryornot" },
+    { name = "click" },
+    { name = "jinja2" },
+    { name = "python-slugify" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/17/9f2cd228eb949a91915acd38d3eecdc9d8893dde353b603f0db7e9f6be55/cookiecutter-2.6.0.tar.gz", hash = "sha256:db21f8169ea4f4fdc2408d48ca44859349de2647fbe494a9d6c3edfc0542c21c", size = 158767, upload-time = "2024-02-21T18:02:41.949Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/d9/0137658a353168ffa9d0fc14b812d3834772040858ddd1cb6eeaf09f7a44/cookiecutter-2.6.0-py3-none-any.whl", hash = "sha256:a54a8e37995e4ed963b3e82831072d1ad4b005af736bb17b99c2cbd9d41b6e2d", size = 39177, upload-time = "2024-02-21T18:02:39.569Z" },
 ]
 
 [[package]]
@@ -380,6 +437,30 @@ wheels = [
 ]
 
 [[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.45"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/c8/dd58967d119baab745caec2f9d853297cec1989ec1d63f677d3880632b88/gitpython-3.1.45.tar.gz", hash = "sha256:85b0ee964ceddf211c41b9f27a49086010a190fd8132a24e21f362a4b36a791c", size = 215076, upload-time = "2025-07-24T03:45:54.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/61/d4b89fec821f72385526e1b9d9a3a0385dda4a72b206d28049e2c7cd39b8/gitpython-3.1.45-py3-none-any.whl", hash = "sha256:8908cb2e02fb3b93b7eb0f2827125cb699869470432cc885f019b8fd0fccff77", size = 208168, upload-time = "2025-07-24T03:45:52.517Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -479,6 +560,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -926,6 +1019,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -941,6 +1046,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
+]
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
 ]
 
 [[package]]
@@ -1182,6 +1299,15 @@ wheels = [
 ]
 
 [[package]]
+name = "smmap"
+version = "5.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329, upload-time = "2025-01-02T07:14:40.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303, upload-time = "2025-01-02T07:14:38.724Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1213,6 +1339,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/15/b9/cc3017f9a9c9b6e27c5106cc10cc7904653c3eec0729793aec10479dd669/starlette-0.47.3.tar.gz", hash = "sha256:6bc94f839cc176c4858894f1f8908f0ab79dfec1a6b8402f6da9be26ebea52e9", size = 2584144, upload-time = "2025-08-24T13:36:42.122Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/fd/901cfa59aaa5b30a99e16876f11abe38b59a1a2c51ffb3d7142bb6089069/starlette-0.47.3-py3-none-any.whl", hash = "sha256:89c0778ca62a76b826101e7c709e70680a1699ca7da6b44d38eb0a7e61fe4b51", size = 72991, upload-time = "2025-08-24T13:36:40.887Z" },
+]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20250822"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/0a/775f8551665992204c756be326f3575abba58c4a3a52eef9909ef4536428/types_python_dateutil-2.9.0.20250822.tar.gz", hash = "sha256:84c92c34bd8e68b117bff742bc00b692a1e8531262d4507b33afcc9f7716cd53", size = 16084, upload-time = "2025-08-22T03:02:00.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/d9/a29dfa84363e88b053bf85a8b7f212a04f0d7343a4d24933baa45c06e08b/types_python_dateutil-2.9.0.20250822-py3-none-any.whl", hash = "sha256:849d52b737e10a6dc6621d2bd7940ec7c65fcb69e6aa2882acf4e56b2b508ddc", size = 17892, upload-time = "2025-08-22T03:01:59.436Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## PR Overview
- Add two new project-preparation tools (`check_project_exists`, `get_cookiecutter_instructions`) plus schema/resource guidance helpers to the MCP server, documenting the canonical BioCypher references throughout `src/biocypher_mcp/main.py`.
- Extend the FastMCP entry point to support both stdio and HTTP transports via CLI flags, expose matching FastAPI endpoints, and register every tool with both transports.
- Refresh README and tests so the published workflows, API surface, and setup instructions—including local/remote MCP configuration snippets—match the implemented behavior.
- Bring in runtime dependencies (`cookiecutter`, `gitpython`) and regenerate `uv.lock` to cover the new features.

## Detailed Changes
- `src/biocypher_mcp/main.py`
  - Adds project workflow metadata, rich doc references, `get_schema_configuration_guidance`, `get_resource_management_guidance`, `check_project_exists`, and `get_cookiecutter_instructions`.
  - Registers the new tools with FastMCP and replaces the fixed uvicorn runner with an argparse-driven CLI that can run `stdio` (default) or `http`.
- `src/biocypher_mcp/web_server.py`
  - Imports the project tools and exposes `/project/check` (POST) plus `/project/cookiecutter-instructions` (GET).
- `README.md`
  - Documents every tool and endpoint, replaces the old `create_biocypher_project` references with the new helpers, and adds MCP configuration snippets for remote access or local uv/venv execution.
- `tests/test_mcp_tools.py`
  - Updates workflow expectations, asserts the presence of supporting tools, and adds complete coverage for the new project utilities.
- `pyproject.toml`, `uv.lock`
  - Adds `cookiecutter` and `gitpython` dependencies required for scripted project scaffolding.